### PR TITLE
Add referenced explanations for quizzes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -281,6 +281,67 @@ button.secondary:hover {
   background: #f8fafc;
   border: 1px solid var(--border);
   font-size: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.explanation-block h4 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: var(--primary-dark);
+}
+
+.explanation-block p {
+  margin: 0 0 8px;
+}
+
+.explanation-block p:last-child {
+  margin-bottom: 0;
+}
+
+.explanation-reference {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.explanation-reference a {
+  color: var(--primary-dark);
+  text-decoration: underline;
+}
+
+.choice-explanations {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.choice-explanation-item {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.choice-explanation-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.choice-statement {
+  margin: 0;
+  font-weight: 600;
+}
+
+.choice-explanation-body p {
+  margin: 0;
+}
+
+.choice-explanation-body p + p {
+  margin-top: 4px;
 }
 
 .results-summary {

--- a/data/aws_cloud_practitioner.json
+++ b/data/aws_cloud_practitioner.json
@@ -1,70 +1,250 @@
 {
-  "exam": {
-    "id": "aws_clf",
-    "title": "AWS Certified Cloud Practitioner",
-    "description": "クラウドの基本概念とAWSサービスの概要を問う入門資格です。",
-    "version": "2023.2"
-  },
-  "questions": [
-    {
-      "id": "clf-q1",
-      "question": "AWSの責任共有モデルにおいてAWSが責任を負う領域はどれか。",
-      "choices": [
-        {"key": "A", "text": "基盤となるハードウェアとネットワークインフラの保守"},
-        {"key": "B", "text": "アプリケーションコードのセキュリティ設計"},
-        {"key": "C", "text": "IAMポリシーの詳細設定"},
-        {"key": "D", "text": "保存データの暗号化キー管理"}
-      ],
-      "answer": "A",
-      "explanation": "AWSはハードウェア、ソフトウェア、ネットワーキングなどクラウドの基盤に責任を持ち、顧客はOSやアプリケーション、データの保護を担当します。"
+    "exam": {
+        "id": "aws_clf",
+        "title": "AWS Certified Cloud Practitioner",
+        "description": "\u30af\u30e9\u30a6\u30c9\u306e\u57fa\u672c\u6982\u5ff5\u3068AWS\u30b5\u30fc\u30d3\u30b9\u306e\u6982\u8981\u3092\u554f\u3046\u5165\u9580\u8cc7\u683c\u3067\u3059\u3002",
+        "version": "2023.2"
     },
-    {
-      "id": "clf-q2",
-      "question": "AWSの料金モデルで従量課金として最も適切な説明はどれか。",
-      "choices": [
-        {"key": "A", "text": "月額固定料金でリソース使用量に関係なく課金される"},
-        {"key": "B", "text": "利用した分だけ料金が発生し、使わなければ課金されない"},
-        {"key": "C", "text": "リザーブドインスタンスを契約すると無料になる"},
-        {"key": "D", "text": "前払いでのみ支払う必要がある"}
-      ],
-      "answer": "B",
-      "explanation": "AWSの多くのサービスは従量課金で、利用した分のみ課金されます。リザーブドインスタンスなど他の購入オプションも存在します。"
-    },
-    {
-      "id": "clf-q3",
-      "question": "AWSのサービスでコスト予測と予算管理を支援するのはどれか。",
-      "choices": [
-        {"key": "A", "text": "AWS Budgets"},
-        {"key": "B", "text": "AWS Trusted Advisor"},
-        {"key": "C", "text": "Amazon CloudFront"},
-        {"key": "D", "text": "AWS Artifact"}
-      ],
-      "answer": "A",
-      "explanation": "AWS Budgetsはコストや使用量の予算を設定し、閾値を超えると通知を送る機能を提供します。"
-    },
-    {
-      "id": "clf-q4",
-      "question": "世界中のユーザーにコンテンツを低遅延で配信するのに最適なサービスはどれか。",
-      "choices": [
-        {"key": "A", "text": "Amazon S3"},
-        {"key": "B", "text": "Amazon CloudFront"},
-        {"key": "C", "text": "AWS Lambda"},
-        {"key": "D", "text": "Amazon RDS"}
-      ],
-      "answer": "B",
-      "explanation": "Amazon CloudFrontはエッジロケーションを活用してグローバルにコンテンツをキャッシュし、低遅延で配信します。"
-    },
-    {
-      "id": "clf-q5",
-      "question": "24時間365日の技術サポートとアーキテクトによるガイダンスを受けるために必要なサポートプランはどれか。",
-      "choices": [
-        {"key": "A", "text": "ベーシックサポート"},
-        {"key": "B", "text": "デベロッパーサポート"},
-        {"key": "C", "text": "ビジネスサポート"},
-        {"key": "D", "text": "エンタープライズサポート"}
-      ],
-      "answer": "D",
-      "explanation": "エンタープライズサポートプランは24/7のサポートやテクニカルアカウントマネージャーへのアクセスを提供します。"
-    }
-  ]
+    "questions": [
+        {
+            "id": "clf-q1",
+            "question": "AWS\u306e\u8cac\u4efb\u5171\u6709\u30e2\u30c7\u30eb\u306b\u304a\u3044\u3066AWS\u304c\u8cac\u4efb\u3092\u8ca0\u3046\u9818\u57df\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u57fa\u76e4\u3068\u306a\u308b\u30cf\u30fc\u30c9\u30a6\u30a7\u30a2\u3068\u30cd\u30c3\u30c8\u30ef\u30fc\u30af\u30a4\u30f3\u30d5\u30e9\u306e\u4fdd\u5b88",
+                    "explanation": {
+                        "text": "AWS\u306f\u30c7\u30fc\u30bf\u30bb\u30f3\u30bf\u30fc\u65bd\u8a2d\u3001\u30cf\u30fc\u30c9\u30a6\u30a7\u30a2\u3001\u30cd\u30c3\u30c8\u30ef\u30fc\u30af\u3001\u4eee\u60f3\u5316\u30ec\u30a4\u30e4\u30fc\u306a\u3069\u30af\u30e9\u30a6\u30c9\u3092\u69cb\u6210\u3059\u308b\u30a4\u30f3\u30d5\u30e9\u30b9\u30c8\u30e9\u30af\u30c1\u30e3\u306e\u4fdd\u8b77\u3092\u62c5\u5f53\u3057\u307e\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/compliance/shared-responsibility-model/",
+                        "reference_label": "AWS \u5171\u6709\u8cac\u4efb\u30e2\u30c7\u30eb"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u30b3\u30fc\u30c9\u306e\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u8a08",
+                    "explanation": {
+                        "text": "\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3084\u30b3\u30fc\u30c9\u306e\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u8a2d\u8a08\u306f\u5229\u7528\u8005\u304c\u62c5\u3046 \"in the cloud\" \u306e\u8cac\u4efb\u9818\u57df\u3067\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/compliance/shared-responsibility-model/",
+                        "reference_label": "AWS \u5171\u6709\u8cac\u4efb\u30e2\u30c7\u30eb"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "IAM\u30dd\u30ea\u30b7\u30fc\u306e\u8a73\u7d30\u8a2d\u5b9a",
+                    "explanation": {
+                        "text": "IAM\u30e6\u30fc\u30b6\u30fc\u3084\u30dd\u30ea\u30b7\u30fc\u306e\u8a2d\u5b9a\u3068\u7ba1\u7406\u306f\u9867\u5ba2\u306e\u8cac\u4efb\u3067\u3042\u308a\u3001AWS\u306f\u30a4\u30f3\u30d5\u30e9\u5c64\u3092\u4fdd\u8b77\u3057\u307e\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/compliance/shared-responsibility-model/",
+                        "reference_label": "AWS \u5171\u6709\u8cac\u4efb\u30e2\u30c7\u30eb"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u4fdd\u5b58\u30c7\u30fc\u30bf\u306e\u6697\u53f7\u5316\u30ad\u30fc\u7ba1\u7406",
+                    "explanation": {
+                        "text": "\u4fdd\u5b58\u30c7\u30fc\u30bf\u3068\u6697\u53f7\u5316\u30ad\u30fc\u306e\u7ba1\u7406\u306f\u9867\u5ba2\u304c\u62c5\u3046\u30af\u30e9\u30a6\u30c9\u5185\u306e\u8cac\u4efb\u7bc4\u56f2\u306b\u542b\u307e\u308c\u307e\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/compliance/shared-responsibility-model/",
+                        "reference_label": "AWS \u5171\u6709\u8cac\u4efb\u30e2\u30c7\u30eb"
+                    }
+                }
+            ],
+            "answer": "A",
+            "explanation": {
+                "text": "AWS\u306e\u8cac\u4efb\u5171\u6709\u30e2\u30c7\u30eb\u3067\u306f\u3001AWS\u304c\u30af\u30e9\u30a6\u30c9\u306e\u30a4\u30f3\u30d5\u30e9\u30b9\u30c8\u30e9\u30af\u30c1\u30e3\uff08\u65bd\u8a2d\u3001\u30cf\u30fc\u30c9\u30a6\u30a7\u30a2\u3001\u30cd\u30c3\u30c8\u30ef\u30fc\u30af\u3001\u4eee\u60f3\u5316\u30ec\u30a4\u30e4\u30fc\uff09\u3092\u4fdd\u8b77\u3057\u3001\u5229\u7528\u8005\u306fOS\u3001\u30a2\u30d7\u30ea\u30b1\u30fc\u30b7\u30e7\u30f3\u3001\u30c7\u30fc\u30bf\u306a\u3069\u30af\u30e9\u30a6\u30c9\u5185\u306e\u7ba1\u7406\u3092\u62c5\u5f53\u3057\u307e\u3059\u3002",
+                "reference": "https://aws.amazon.com/jp/compliance/shared-responsibility-model/",
+                "reference_label": "AWS \u5171\u6709\u8cac\u4efb\u30e2\u30c7\u30eb"
+            }
+        },
+        {
+            "id": "clf-q2",
+            "question": "AWS\u306e\u6599\u91d1\u30e2\u30c7\u30eb\u3067\u5f93\u91cf\u8ab2\u91d1\u3068\u3057\u3066\u6700\u3082\u9069\u5207\u306a\u8aac\u660e\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u6708\u984d\u56fa\u5b9a\u6599\u91d1\u3067\u30ea\u30bd\u30fc\u30b9\u4f7f\u7528\u91cf\u306b\u95a2\u4fc2\u306a\u304f\u8ab2\u91d1\u3055\u308c\u308b",
+                    "explanation": {
+                        "text": "\u5f93\u91cf\u8ab2\u91d1\u3067\u306f\u4f7f\u7528\u91cf\u306b\u5fdc\u3058\u3066\u8ab2\u91d1\u3055\u308c\u308b\u305f\u3081\u3001\u56fa\u5b9a\u6599\u91d1\u3067\u4f7f\u7528\u91cf\u306b\u95a2\u4fc2\u306a\u304f\u652f\u6255\u3046\u65b9\u5f0f\u3068\u306f\u7570\u306a\u308a\u307e\u3059\u3002",
+                        "reference": "https://docs.aws.amazon.com/whitepapers/latest/how-aws-pricing-works/introduction-to-aws-pricing.html",
+                        "reference_label": "How AWS Pricing Works"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u5229\u7528\u3057\u305f\u5206\u3060\u3051\u6599\u91d1\u304c\u767a\u751f\u3057\u3001\u4f7f\u308f\u306a\u3051\u308c\u3070\u8ab2\u91d1\u3055\u308c\u306a\u3044",
+                    "explanation": {
+                        "text": "AWS\u306e\u5f93\u91cf\u8ab2\u91d1\uff08Pay-as-you-go\uff09\u3067\u306f\u5229\u7528\u3057\u305f\u30ea\u30bd\u30fc\u30b9\u5206\u3060\u3051\u652f\u6255\u3044\u3001\u672a\u4f7f\u7528\u5206\u306b\u306f\u6599\u91d1\u304c\u767a\u751f\u3057\u307e\u305b\u3093\u3002",
+                        "reference": "https://docs.aws.amazon.com/whitepapers/latest/how-aws-pricing-works/introduction-to-aws-pricing.html",
+                        "reference_label": "How AWS Pricing Works"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "\u30ea\u30b6\u30fc\u30d6\u30c9\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u3092\u5951\u7d04\u3059\u308b\u3068\u7121\u6599\u306b\u306a\u308b",
+                    "explanation": {
+                        "text": "\u30ea\u30b6\u30fc\u30d6\u30c9\u30a4\u30f3\u30b9\u30bf\u30f3\u30b9\u306f\u9577\u671f\u5229\u7528\u3092\u524d\u63d0\u306b\u5272\u5f15\u3092\u53d7\u3051\u3089\u308c\u308b\u8cfc\u5165\u30aa\u30d7\u30b7\u30e7\u30f3\u3067\u3042\u308a\u3001\u7121\u6599\u306b\u306a\u308b\u308f\u3051\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://docs.aws.amazon.com/whitepapers/latest/how-aws-pricing-works/introduction-to-aws-pricing.html",
+                        "reference_label": "How AWS Pricing Works"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u524d\u6255\u3044\u3067\u306e\u307f\u652f\u6255\u3046\u5fc5\u8981\u304c\u3042\u308b",
+                    "explanation": {
+                        "text": "\u5f93\u91cf\u8ab2\u91d1\u306f\u30ea\u30bd\u30fc\u30b9\u3092\u6d88\u8cbb\u3057\u305f\u5206\u3060\u3051\u5f8c\u6255\u3044\u3067\u8acb\u6c42\u3055\u308c\u3001\u524d\u6255\u3044\u304c\u5fc5\u9808\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://docs.aws.amazon.com/whitepapers/latest/how-aws-pricing-works/introduction-to-aws-pricing.html",
+                        "reference_label": "How AWS Pricing Works"
+                    }
+                }
+            ],
+            "answer": "B",
+            "explanation": {
+                "text": "AWS\u306e\u5f93\u91cf\u8ab2\u91d1\u30e2\u30c7\u30eb\u306f\u30ea\u30bd\u30fc\u30b9\u306e\u5229\u7528\u91cf\u306b\u5fdc\u3058\u3066\u6599\u91d1\u304c\u767a\u751f\u3059\u308b\u4ed5\u7d44\u307f\u3067\u3001\u4f7f\u308f\u306a\u3051\u308c\u3070\u8ab2\u91d1\u3055\u308c\u307e\u305b\u3093\u3002",
+                "reference": "https://docs.aws.amazon.com/whitepapers/latest/how-aws-pricing-works/introduction-to-aws-pricing.html",
+                "reference_label": "How AWS Pricing Works"
+            }
+        },
+        {
+            "id": "clf-q3",
+            "question": "AWS\u306e\u30b5\u30fc\u30d3\u30b9\u3067\u30b3\u30b9\u30c8\u4e88\u6e2c\u3068\u4e88\u7b97\u7ba1\u7406\u3092\u652f\u63f4\u3059\u308b\u306e\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "AWS Budgets",
+                    "explanation": {
+                        "text": "AWS Budgets\u306f\u30b3\u30b9\u30c8\u3084\u4f7f\u7528\u91cf\u306e\u4e88\u7b97\u3092\u8a2d\u5b9a\u3057\u3001\u95be\u5024\u3092\u8d85\u3048\u305f\u969b\u306e\u30a2\u30e9\u30fc\u30c8\u901a\u77e5\u3092\u63d0\u4f9b\u3057\u307e\u3059\u3002",
+                        "reference": "https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html",
+                        "reference_label": "AWS Budgets \u30e6\u30fc\u30b6\u30fc\u30ac\u30a4\u30c9"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "AWS Trusted Advisor",
+                    "explanation": {
+                        "text": "Trusted Advisor\u306f\u30b3\u30b9\u30c8\u6700\u9069\u5316\u3084\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u306a\u3069\u306e\u30d9\u30b9\u30c8\u30d7\u30e9\u30af\u30c6\u30a3\u30b9\u3092\u30c1\u30a7\u30c3\u30af\u3059\u308b\u30b5\u30fc\u30d3\u30b9\u3067\u3001\u4e88\u7b97\u30a2\u30e9\u30fc\u30c8\u306f\u63d0\u4f9b\u3057\u307e\u305b\u3093\u3002",
+                        "reference": "https://docs.aws.amazon.com/awssupport/latest/user/trusted-advisor.html",
+                        "reference_label": "AWS Trusted Advisor \u30c9\u30ad\u30e5\u30e1\u30f3\u30c8"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "Amazon CloudFront",
+                    "explanation": {
+                        "text": "CloudFront\u306f\u30b0\u30ed\u30fc\u30d0\u30eb\u914d\u4fe1\u306e\u305f\u3081\u306e\u30b3\u30f3\u30c6\u30f3\u30c4\u914d\u4fe1\u30cd\u30c3\u30c8\u30ef\u30fc\u30af\uff08CDN\uff09\u3067\u3042\u308a\u3001\u30b3\u30b9\u30c8\u4e88\u7b97\u7ba1\u7406\u306e\u6a5f\u80fd\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html",
+                        "reference_label": "Amazon CloudFront \u958b\u767a\u8005\u30ac\u30a4\u30c9"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "AWS Artifact",
+                    "explanation": {
+                        "text": "AWS Artifact\u306f\u76e3\u67fb\u30ec\u30dd\u30fc\u30c8\u306a\u3069\u306e\u30b3\u30f3\u30d7\u30e9\u30a4\u30a2\u30f3\u30b9\u8cc7\u6599\u3092\u63d0\u4f9b\u3059\u308b\u30b5\u30fc\u30d3\u30b9\u3067\u3001\u30b3\u30b9\u30c8\u7ba1\u7406\u3092\u76ee\u7684\u3068\u3057\u3066\u3044\u307e\u305b\u3093\u3002",
+                        "reference": "https://docs.aws.amazon.com/artifact/latest/ug/what-is-aws-artifact.html",
+                        "reference_label": "AWS Artifact \u30e6\u30fc\u30b6\u30fc\u30ac\u30a4\u30c9"
+                    }
+                }
+            ],
+            "answer": "A",
+            "explanation": {
+                "text": "AWS Budgets\u306f\u5229\u7528\u6599\u91d1\u3084\u4f7f\u7528\u91cf\u306e\u4e88\u7b97\u3092\u8a2d\u5b9a\u3057\u3001\u95be\u5024\u306b\u9054\u3057\u305f\u969b\u306b\u901a\u77e5\u3092\u9001\u308b\u3053\u3068\u3067\u30b3\u30b9\u30c8\u7ba1\u7406\u3092\u652f\u63f4\u3057\u307e\u3059\u3002",
+                "reference": "https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html",
+                "reference_label": "AWS Budgets \u30e6\u30fc\u30b6\u30fc\u30ac\u30a4\u30c9"
+            }
+        },
+        {
+            "id": "clf-q4",
+            "question": "\u4e16\u754c\u4e2d\u306e\u30e6\u30fc\u30b6\u30fc\u306b\u30b3\u30f3\u30c6\u30f3\u30c4\u3092\u4f4e\u9045\u5ef6\u3067\u914d\u4fe1\u3059\u308b\u306e\u306b\u6700\u9069\u306a\u30b5\u30fc\u30d3\u30b9\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "Amazon S3",
+                    "explanation": {
+                        "text": "Amazon S3\u306f\u30aa\u30d6\u30b8\u30a7\u30af\u30c8\u30b9\u30c8\u30ec\u30fc\u30b8\u30b5\u30fc\u30d3\u30b9\u3067\u3042\u308a\u3001\u914d\u4fe1\u81ea\u4f53\u306f\u5225\u30b5\u30fc\u30d3\u30b9\uff08CloudFront\u306a\u3069\uff09\u3068\u7d44\u307f\u5408\u308f\u305b\u3066\u884c\u3044\u307e\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/s3/",
+                        "reference_label": "Amazon S3"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "Amazon CloudFront",
+                    "explanation": {
+                        "text": "CloudFront\u306f\u4e16\u754c\u4e2d\u306e\u30a8\u30c3\u30b8\u30ed\u30b1\u30fc\u30b7\u30e7\u30f3\u304b\u3089\u30b3\u30f3\u30c6\u30f3\u30c4\u3092\u30ad\u30e3\u30c3\u30b7\u30e5\u3057\u3066\u914d\u4fe1\u3057\u3001\u4f4e\u9045\u5ef6\u30a2\u30af\u30bb\u30b9\u3092\u5b9f\u73fe\u3057\u307e\u3059\u3002",
+                        "reference": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html",
+                        "reference_label": "Amazon CloudFront \u958b\u767a\u8005\u30ac\u30a4\u30c9"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "AWS Lambda",
+                    "explanation": {
+                        "text": "AWS Lambda\u306f\u30b5\u30fc\u30d0\u30fc\u30ec\u30b9\u3067\u30b3\u30fc\u30c9\u3092\u5b9f\u884c\u3059\u308b\u30b3\u30f3\u30d4\u30e5\u30fc\u30c8\u30b5\u30fc\u30d3\u30b9\u3067\u3042\u308a\u3001\u30b3\u30f3\u30c6\u30f3\u30c4\u914d\u4fe1\u3092\u76ee\u7684\u3068\u3057\u3066\u3044\u307e\u305b\u3093\u3002",
+                        "reference": "https://aws.amazon.com/jp/lambda/",
+                        "reference_label": "AWS Lambda"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "Amazon RDS",
+                    "explanation": {
+                        "text": "Amazon RDS\u306f\u30de\u30cd\u30fc\u30b8\u30c9\u306a\u30ea\u30ec\u30fc\u30b7\u30e7\u30ca\u30eb\u30c7\u30fc\u30bf\u30d9\u30fc\u30b9\u30b5\u30fc\u30d3\u30b9\u3067\u3001\u914d\u4fe1\u30cd\u30c3\u30c8\u30ef\u30fc\u30af\u306e\u6a5f\u80fd\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://aws.amazon.com/jp/rds/",
+                        "reference_label": "Amazon RDS"
+                    }
+                }
+            ],
+            "answer": "B",
+            "explanation": {
+                "text": "Amazon CloudFront\u306f\u30b0\u30ed\u30fc\u30d0\u30eb\u306a\u30a8\u30c3\u30b8\u30ed\u30b1\u30fc\u30b7\u30e7\u30f3\u3092\u6d3b\u7528\u3057\u3066\u30b3\u30f3\u30c6\u30f3\u30c4\u3092\u30ad\u30e3\u30c3\u30b7\u30e5\u3057\u3001\u5229\u7528\u8005\u306b\u4f4e\u9045\u5ef6\u3067\u914d\u4fe1\u3059\u308b\u305f\u3081\u306e\u30b5\u30fc\u30d3\u30b9\u3067\u3059\u3002",
+                "reference": "https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Introduction.html",
+                "reference_label": "Amazon CloudFront \u958b\u767a\u8005\u30ac\u30a4\u30c9"
+            }
+        },
+        {
+            "id": "clf-q5",
+            "question": "24\u6642\u9593365\u65e5\u306e\u6280\u8853\u30b5\u30dd\u30fc\u30c8\u3068\u30a2\u30fc\u30ad\u30c6\u30af\u30c8\u306b\u3088\u308b\u30ac\u30a4\u30c0\u30f3\u30b9\u3092\u53d7\u3051\u308b\u305f\u3081\u306b\u5fc5\u8981\u306a\u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u30d9\u30fc\u30b7\u30c3\u30af\u30b5\u30dd\u30fc\u30c8",
+                    "explanation": {
+                        "text": "\u30d9\u30fc\u30b7\u30c3\u30af\u30b5\u30dd\u30fc\u30c8\u306f\u30a2\u30ab\u30a6\u30f3\u30c8\u3068\u8ab2\u91d1\u306b\u95a2\u3059\u308b\u30b5\u30dd\u30fc\u30c8\u3084\u30c9\u30ad\u30e5\u30e1\u30f3\u30c8\u306e\u5229\u7528\u304c\u4e2d\u5fc3\u3067\u300124/7\u306e\u6280\u8853\u30b5\u30dd\u30fc\u30c8\u3084\u30a2\u30fc\u30ad\u30c6\u30af\u30c8\u652f\u63f4\u306f\u542b\u307e\u308c\u307e\u305b\u3093\u3002",
+                        "reference": "https://aws.amazon.com/jp/premiumsupport/plans/",
+                        "reference_label": "AWS \u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u30c7\u30d9\u30ed\u30c3\u30d1\u30fc\u30b5\u30dd\u30fc\u30c8",
+                    "explanation": {
+                        "text": "\u30c7\u30d9\u30ed\u30c3\u30d1\u30fc\u30b5\u30dd\u30fc\u30c8\u306f\u958b\u767a\u30fb\u30c6\u30b9\u30c8\u74b0\u5883\u5411\u3051\u3067\u3001\u55b6\u696d\u6642\u9593\u5185\u306e\u30b5\u30dd\u30fc\u30c8\u304c\u4e2d\u5fc3\u3067\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/premiumsupport/plans/",
+                        "reference_label": "AWS \u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "\u30d3\u30b8\u30cd\u30b9\u30b5\u30dd\u30fc\u30c8",
+                    "explanation": {
+                        "text": "\u30d3\u30b8\u30cd\u30b9\u30b5\u30dd\u30fc\u30c8\u306f24/7\u306e\u30b5\u30dd\u30fc\u30c8\u3092\u63d0\u4f9b\u3057\u307e\u3059\u304c\u3001\u5c02\u4efb\u306e\u30c6\u30af\u30cb\u30ab\u30eb\u30a2\u30ab\u30a6\u30f3\u30c8\u30de\u30cd\u30fc\u30b8\u30e3\u30fc\uff08TAM\uff09\u306f\u542b\u307e\u308c\u307e\u305b\u3093\u3002",
+                        "reference": "https://aws.amazon.com/jp/premiumsupport/plans/",
+                        "reference_label": "AWS \u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u30a8\u30f3\u30bf\u30fc\u30d7\u30e9\u30a4\u30ba\u30b5\u30dd\u30fc\u30c8",
+                    "explanation": {
+                        "text": "\u30a8\u30f3\u30bf\u30fc\u30d7\u30e9\u30a4\u30ba\u30b5\u30dd\u30fc\u30c8\u306f24\u6642\u9593365\u65e5\u5bfe\u5fdc\u306b\u52a0\u3048\u3066TAM\u3092\u542b\u3080\u30a2\u30fc\u30ad\u30c6\u30af\u30c8\u652f\u63f4\u304c\u63d0\u4f9b\u3055\u308c\u307e\u3059\u3002",
+                        "reference": "https://aws.amazon.com/jp/premiumsupport/plans/",
+                        "reference_label": "AWS \u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3"
+                    }
+                }
+            ],
+            "answer": "D",
+            "explanation": {
+                "text": "\u30a8\u30f3\u30bf\u30fc\u30d7\u30e9\u30a4\u30ba\u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3\u3067\u306f\u300124\u6642\u9593365\u65e5\u306e\u6280\u8853\u30b5\u30dd\u30fc\u30c8\u3068\u5c02\u4efbTAM\u306b\u3088\u308b\u30a2\u30fc\u30ad\u30c6\u30af\u30c8\u652f\u63f4\u304c\u63d0\u4f9b\u3055\u308c\u307e\u3059\u3002",
+                "reference": "https://aws.amazon.com/jp/premiumsupport/plans/",
+                "reference_label": "AWS \u30b5\u30dd\u30fc\u30c8\u30d7\u30e9\u30f3"
+            }
+        }
+    ]
 }

--- a/data/basic_it_passport.json
+++ b/data/basic_it_passport.json
@@ -1,70 +1,250 @@
 {
-  "exam": {
-    "id": "it_passport",
-    "title": "ITパスポート試験",
-    "description": "情報処理の基礎知識を幅広く問う国家試験です。",
-    "version": "2023"
-  },
-  "questions": [
-    {
-      "id": "ip-q1",
-      "question": "PDCAサイクルの\"C\"が示す活動はどれか。",
-      "choices": [
-        {"key": "A", "text": "Check"},
-        {"key": "B", "text": "Create"},
-        {"key": "C", "text": "Control"},
-        {"key": "D", "text": "Communicate"}
-      ],
-      "answer": "A",
-      "explanation": "PDCAサイクルはPlan、Do、Check、Actの順で進み、Checkは実施した内容の評価を意味します。"
+    "exam": {
+        "id": "it_passport",
+        "title": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13",
+        "description": "\u60c5\u5831\u51e6\u7406\u306e\u57fa\u790e\u77e5\u8b58\u3092\u5e45\u5e83\u304f\u554f\u3046\u56fd\u5bb6\u8a66\u9a13\u3067\u3059\u3002",
+        "version": "2023"
     },
-    {
-      "id": "ip-q2",
-      "question": "情報セキュリティにおいて機密性を高めるための対策はどれか。",
-      "choices": [
-        {"key": "A", "text": "データの暗号化"},
-        {"key": "B", "text": "冗長構成による耐障害性向上"},
-        {"key": "C", "text": "処理性能の向上"},
-        {"key": "D", "text": "稼働率の計測"}
-      ],
-      "answer": "A",
-      "explanation": "機密性は情報が許可された利用者だけにアクセスできる性質を指し、暗号化は代表的な対策です。"
-    },
-    {
-      "id": "ip-q3",
-      "question": "ソフトウェアライフサイクルで要件を満たしているかを確認する工程はどれか。",
-      "choices": [
-        {"key": "A", "text": "設計"},
-        {"key": "B", "text": "開発"},
-        {"key": "C", "text": "テスト"},
-        {"key": "D", "text": "運用"}
-      ],
-      "answer": "C",
-      "explanation": "テスト工程は開発したソフトウェアが要件を満たしているかを確認します。"
-    },
-    {
-      "id": "ip-q4",
-      "question": "プロジェクトマネジメントにおけるクリティカルパスの説明として適切なのはどれか。",
-      "choices": [
-        {"key": "A", "text": "最もコストがかかるタスクの連なり"},
-        {"key": "B", "text": "最も資源を消費するタスクの連なり"},
-        {"key": "C", "text": "プロジェクトの最短完了時間を決めるタスクの連なり"},
-        {"key": "D", "text": "最も人員を割り当てたタスクの連なり"}
-      ],
-      "answer": "C",
-      "explanation": "クリティカルパスはプロジェクトの最短完了時間を決定するタスクの経路であり、遅延するとプロジェクト全体に影響します。"
-    },
-    {
-      "id": "ip-q5",
-      "question": "企業の経営戦略においてSWOT分析で外部環境として扱われる要素はどれか。",
-      "choices": [
-        {"key": "A", "text": "自社の強み"},
-        {"key": "B", "text": "自社の弱み"},
-        {"key": "C", "text": "市場機会"},
-        {"key": "D", "text": "組織構造"}
-      ],
-      "answer": "C",
-      "explanation": "SWOT分析の外部環境は機会と脅威で構成され、市場機会は外部要因として評価します。"
-    }
-  ]
+    "questions": [
+        {
+            "id": "ip-q1",
+            "question": "PDCA\u30b5\u30a4\u30af\u30eb\u306e\"C\"\u304c\u793a\u3059\u6d3b\u52d5\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "Check",
+                    "explanation": {
+                        "text": "PDCA\u30b5\u30a4\u30af\u30eb\u306fPlan\uff08\u8a08\u753b\uff09\u3001Do\uff08\u5b9f\u884c\uff09\u3001Check\uff08\u8a55\u4fa1\uff09\u3001Act\uff08\u6539\u5584\uff09\u306e\u9806\u306b\u6d3b\u52d5\u3092\u7e70\u308a\u8fd4\u3057\u307e\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\uff09"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "Create",
+                    "explanation": {
+                        "text": "PDCA\u306e4\u6bb5\u968e\u306bCreate\u306f\u542b\u307e\u308c\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\uff09"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "Control",
+                    "explanation": {
+                        "text": "PDCA\u306eC\u306fCheck\uff08\u8a55\u4fa1\uff09\u3092\u6307\u3057\u3001Control\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\uff09"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "Communicate",
+                    "explanation": {
+                        "text": "Communicate\u306fPDCA\u30b5\u30a4\u30af\u30eb\u306e\u69cb\u6210\u8981\u7d20\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\uff09"
+                    }
+                }
+            ],
+            "answer": "A",
+            "explanation": {
+                "text": "PDCA\u30b5\u30a4\u30af\u30eb\u3067\u306fC\u304cCheck\uff08\u8a55\u4fa1\uff09\u3092\u793a\u3057\u3001\u8a08\u753b\u3068\u5b9f\u884c\u306e\u7d50\u679c\u3092\u78ba\u8a8d\u3057\u3066\u6b21\u306e\u6539\u5584\uff08Act\uff09\u306b\u3064\u306a\u3052\u307e\u3059\u3002",
+                "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\uff09"
+            }
+        },
+        {
+            "id": "ip-q2",
+            "question": "\u60c5\u5831\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u306b\u304a\u3044\u3066\u6a5f\u5bc6\u6027\u3092\u9ad8\u3081\u308b\u305f\u3081\u306e\u5bfe\u7b56\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u30c7\u30fc\u30bf\u306e\u6697\u53f7\u5316",
+                    "explanation": {
+                        "text": "\u6a5f\u5bc6\u6027\u306f\u60c5\u5831\u3078\u30a2\u30af\u30bb\u30b9\u3067\u304d\u308b\u4e3b\u4f53\u3092\u5236\u9650\u3059\u308b\u6027\u8cea\u3067\u3042\u308a\u3001\u6697\u53f7\u5316\u306f\u4ee3\u8868\u7684\u306a\u5bfe\u7b56\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\uff09"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u5197\u9577\u69cb\u6210\u306b\u3088\u308b\u8010\u969c\u5bb3\u6027\u5411\u4e0a",
+                    "explanation": {
+                        "text": "\u5197\u9577\u5316\u306f\u4e3b\u306b\u53ef\u7528\u6027\u306e\u78ba\u4fdd\u3092\u76ee\u7684\u3068\u3057\u305f\u5bfe\u7b56\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\uff09"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "\u51e6\u7406\u6027\u80fd\u306e\u5411\u4e0a",
+                    "explanation": {
+                        "text": "\u51e6\u7406\u6027\u80fd\u306e\u5411\u4e0a\u306f\u30d1\u30d5\u30a9\u30fc\u30de\u30f3\u30b9\u6539\u5584\u3067\u3042\u308a\u3001\u6a5f\u5bc6\u6027\u306e\u78ba\u4fdd\u306b\u306f\u76f4\u63a5\u3064\u306a\u304c\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\uff09"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u7a3c\u50cd\u7387\u306e\u8a08\u6e2c",
+                    "explanation": {
+                        "text": "\u7a3c\u50cd\u7387\u306e\u8a08\u6e2c\u306f\u53ef\u7528\u6027\u306e\u8a55\u4fa1\u3067\u3042\u308a\u3001\u6a5f\u5bc6\u6027\u3092\u9ad8\u3081\u308b\u5bfe\u7b56\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\uff09"
+                    }
+                }
+            ],
+            "answer": "A",
+            "explanation": {
+                "text": "\u60c5\u5831\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\u306eCIA\u306e\u3046\u3061\u6a5f\u5bc6\u6027\u3092\u5b88\u308b\u305f\u3081\u306b\u306f\u3001\u6697\u53f7\u5316\u306a\u3069\u306b\u3088\u308a\u8a31\u53ef\u3055\u308c\u305f\u5229\u7528\u8005\u4ee5\u5916\u304c\u5185\u5bb9\u3092\u8aad\u3081\u306a\u3044\u3088\u3046\u306b\u3059\u308b\u5bfe\u7b56\u304c\u6709\u52b9\u3067\u3059\u3002",
+                "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30bb\u30ad\u30e5\u30ea\u30c6\u30a3\uff09"
+            }
+        },
+        {
+            "id": "ip-q3",
+            "question": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30e9\u30a4\u30d5\u30b5\u30a4\u30af\u30eb\u3067\u8981\u4ef6\u3092\u6e80\u305f\u3057\u3066\u3044\u308b\u304b\u3092\u78ba\u8a8d\u3059\u308b\u5de5\u7a0b\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u8a2d\u8a08",
+                    "explanation": {
+                        "text": "\u8a2d\u8a08\u5de5\u7a0b\u3067\u306f\u8981\u4ef6\u3092\u3082\u3068\u306b\u69cb\u9020\u3084\u4ed5\u69d8\u3092\u5b9a\u7fa9\u3057\u307e\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u958b\u767a\uff09"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u958b\u767a",
+                    "explanation": {
+                        "text": "\u958b\u767a\uff08\u5b9f\u88c5\uff09\u5de5\u7a0b\u306f\u8a2d\u8a08\u306b\u5f93\u3063\u3066\u30d7\u30ed\u30b0\u30e9\u30e0\u3092\u4f5c\u6210\u3059\u308b\u6bb5\u968e\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u958b\u767a\uff09"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "\u30c6\u30b9\u30c8",
+                    "explanation": {
+                        "text": "\u30c6\u30b9\u30c8\u5de5\u7a0b\u3067\u306f\u4f5c\u6210\u3057\u305f\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u304c\u8981\u4ef6\u3092\u6e80\u305f\u3057\u3066\u3044\u308b\u304b\u78ba\u8a8d\u3057\u307e\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u958b\u767a\uff09"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u904b\u7528",
+                    "explanation": {
+                        "text": "\u904b\u7528\u5de5\u7a0b\u306f\u30b5\u30fc\u30d3\u30b9\u63d0\u4f9b\u3084\u4fdd\u5b88\u3092\u884c\u3046\u6bb5\u968e\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u958b\u767a\uff09"
+                    }
+                }
+            ],
+            "answer": "C",
+            "explanation": {
+                "text": "\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30c6\u30b9\u30c8\u306e\u5de5\u7a0b\u3067\u8981\u4ef6\u3092\u6e80\u305f\u3057\u3066\u3044\u308b\u304b\u3092\u78ba\u8a8d\u3057\u3001\u554f\u984c\u304c\u3042\u308c\u3070\u4fee\u6b63\u3057\u307e\u3059\u3002",
+                "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u958b\u767a\uff09"
+            }
+        },
+        {
+            "id": "ip-q4",
+            "question": "\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30de\u30cd\u30b8\u30e1\u30f3\u30c8\u306b\u304a\u3051\u308b\u30af\u30ea\u30c6\u30a3\u30ab\u30eb\u30d1\u30b9\u306e\u8aac\u660e\u3068\u3057\u3066\u9069\u5207\u306a\u306e\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u6700\u3082\u30b3\u30b9\u30c8\u304c\u304b\u304b\u308b\u30bf\u30b9\u30af\u306e\u9023\u306a\u308a",
+                    "explanation": {
+                        "text": "\u30af\u30ea\u30c6\u30a3\u30ab\u30eb\u30d1\u30b9\u306f\u30b3\u30b9\u30c8\u3067\u306f\u306a\u304f\u3001\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u671f\u9593\u3092\u6c7a\u5b9a\u3059\u308b\u7d4c\u8def\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u7ba1\u7406\uff09"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u6700\u3082\u8cc7\u6e90\u3092\u6d88\u8cbb\u3059\u308b\u30bf\u30b9\u30af\u306e\u9023\u306a\u308a",
+                    "explanation": {
+                        "text": "\u8cc7\u6e90\u6d88\u8cbb\u306e\u5927\u304d\u3055\u3060\u3051\u3067\u30af\u30ea\u30c6\u30a3\u30ab\u30eb\u30d1\u30b9\u306f\u6c7a\u307e\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u7ba1\u7406\uff09"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u306e\u6700\u77ed\u5b8c\u4e86\u6642\u9593\u3092\u6c7a\u3081\u308b\u30bf\u30b9\u30af\u306e\u9023\u306a\u308a",
+                    "explanation": {
+                        "text": "\u30af\u30ea\u30c6\u30a3\u30ab\u30eb\u30d1\u30b9\u306f\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u5168\u4f53\u306e\u6700\u77ed\u5b8c\u4e86\u6642\u9593\u3092\u6c7a\u5b9a\u3059\u308b\u30bf\u30b9\u30af\u306e\u7d4c\u8def\u3092\u6307\u3057\u307e\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u7ba1\u7406\uff09"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u6700\u3082\u4eba\u54e1\u3092\u5272\u308a\u5f53\u3066\u305f\u30bf\u30b9\u30af\u306e\u9023\u306a\u308a",
+                    "explanation": {
+                        "text": "\u5272\u308a\u5f53\u3066\u4eba\u6570\u306e\u591a\u3055\u306f\u30af\u30ea\u30c6\u30a3\u30ab\u30eb\u30d1\u30b9\u306e\u6761\u4ef6\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u7ba1\u7406\uff09"
+                    }
+                }
+            ],
+            "answer": "C",
+            "explanation": {
+                "text": "\u30af\u30ea\u30c6\u30a3\u30ab\u30eb\u30d1\u30b9\u306f\u9045\u5ef6\u3059\u308b\u3068\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u5168\u4f53\u304c\u9045\u308c\u308b\u30bf\u30b9\u30af\u306e\u7d4c\u8def\u3067\u3042\u308a\u3001\u6700\u77ed\u5b8c\u4e86\u6642\u9593\u3092\u898f\u5b9a\u3057\u307e\u3059\u3002",
+                "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u7ba1\u7406\uff09"
+            }
+        },
+        {
+            "id": "ip-q5",
+            "question": "\u4f01\u696d\u306e\u7d4c\u55b6\u6226\u7565\u306b\u304a\u3044\u3066SWOT\u5206\u6790\u3067\u5916\u90e8\u74b0\u5883\u3068\u3057\u3066\u6271\u308f\u308c\u308b\u8981\u7d20\u306f\u3069\u308c\u304b\u3002",
+            "choices": [
+                {
+                    "key": "A",
+                    "text": "\u81ea\u793e\u306e\u5f37\u307f",
+                    "explanation": {
+                        "text": "\u5f37\u307f\uff08Strength\uff09\u306f\u5185\u90e8\u74b0\u5883\u306e\u8981\u7d20\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u7d4c\u55b6\u6226\u7565\uff09"
+                    }
+                },
+                {
+                    "key": "B",
+                    "text": "\u81ea\u793e\u306e\u5f31\u307f",
+                    "explanation": {
+                        "text": "\u5f31\u307f\uff08Weakness\uff09\u3082\u5185\u90e8\u74b0\u5883\u306b\u5206\u985e\u3055\u308c\u307e\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u7d4c\u55b6\u6226\u7565\uff09"
+                    }
+                },
+                {
+                    "key": "C",
+                    "text": "\u5e02\u5834\u6a5f\u4f1a",
+                    "explanation": {
+                        "text": "\u5e02\u5834\u6a5f\u4f1a\uff08Opportunity\uff09\u306f\u5916\u90e8\u74b0\u5883\u306e\u30d7\u30e9\u30b9\u8981\u56e0\u3068\u3057\u3066\u5206\u6790\u3057\u307e\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u7d4c\u55b6\u6226\u7565\uff09"
+                    }
+                },
+                {
+                    "key": "D",
+                    "text": "\u7d44\u7e54\u69cb\u9020",
+                    "explanation": {
+                        "text": "\u7d44\u7e54\u69cb\u9020\u306f\u5185\u90e8\u74b0\u5883\u306e\u8981\u7d20\u3067\u3059\u3002",
+                        "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                        "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u7d4c\u55b6\u6226\u7565\uff09"
+                    }
+                }
+            ],
+            "answer": "C",
+            "explanation": {
+                "text": "SWOT\u5206\u6790\u3067\u306f\u5e02\u5834\u6a5f\u4f1a\u3084\u8105\u5a01\u3092\u5916\u90e8\u74b0\u5883\u3068\u3057\u3066\u6349\u3048\u3001\u6226\u7565\u7b56\u5b9a\u306b\u6d3b\u7528\u3057\u307e\u3059\u3002",
+                "reference": "https://www.ipa.go.jp/jinzai/itpassport/syllabus.html",
+                "reference_label": "IT\u30d1\u30b9\u30dd\u30fc\u30c8\u8a66\u9a13 \u30b7\u30e9\u30d0\u30b9\uff08\u7d4c\u55b6\u6226\u7565\uff09"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- normalize question and choice explanations to include text and official reference links
- render overall and per-choice explanations with reference anchors in the results view
- update quiz datasets with detailed explanations and links to official materials, and adjust styles for the new layout

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ca403281c08327aa0a512bf2d2fa06