### PR TITLE
Fix category selection resetting to default

### DIFF
--- a/index.php
+++ b/index.php
@@ -483,8 +483,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     $postedExamId = isset($_POST['exam_id']) ? (string)$_POST['exam_id'] : '';
     if ($postedExamId !== '' && isset($exams[$postedExamId])) {
-        $selectedExamId = $postedExamId;
-        $selectedCategoryId = $exams[$postedExamId]['meta']['category']['id'];
+        if ($action !== 'change_category') {
+            $selectedExamId = $postedExamId;
+            $selectedCategoryId = $exams[$postedExamId]['meta']['category']['id'];
+        }
     }
 
     if (isset($_POST['question_count'])) {
@@ -493,6 +495,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     switch ($action) {
         case 'change_category':
+            $selectedExamId = '';
             $questionCountInput = '';
             $view = 'home';
             break;


### PR DESCRIPTION
## Summary
- Prevent stale exam selections from overriding the chosen category during category change
- Reset the selected exam when the category changes so the form reflects the newly chosen category

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68ca87ff18e08327b3a6ad3d0eb6f57d