### PR TITLE
Add collapsible choice explanations

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -408,6 +408,51 @@ button.secondary:disabled:hover {
   text-decoration: underline;
 }
 
+.choice-explanations-toggle {
+  display: block;
+}
+
+.choice-explanations-toggle summary {
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--primary-dark);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background 0.2s ease;
+}
+
+.choice-explanations-toggle summary:hover {
+  background: rgba(29, 78, 216, 0.08);
+}
+
+.choice-explanations-toggle summary:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.choice-explanations-toggle summary::-webkit-details-marker {
+  display: none;
+}
+
+.choice-explanations-toggle summary::before {
+  content: "\25B6";
+  font-size: 0.9rem;
+  color: var(--primary);
+  transition: transform 0.2s ease;
+}
+
+.choice-explanations-toggle[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.choice-explanations-toggle[open] summary {
+  margin-bottom: 12px;
+}
+
 .choice-explanations {
   list-style: none;
   padding: 0;

--- a/index.php
+++ b/index.php
@@ -1069,29 +1069,31 @@ $totalCategories = count($categories);
                         <?php endif; ?>
                         <?php if (!empty($choiceExplanationItems)): ?>
                             <div class="explanation-block">
-                                <h4>選択肢ごとの解説</h4>
-                                <ul class="choice-explanations">
-                                    <?php foreach ($choiceExplanationItems as $choiceExplanationItem): ?>
-                                        <?php $choiceExplanation = $choiceExplanationItem['explanation']; ?>
-                                        <li class="choice-explanation-item">
-                                            <span class="option-key"><?php echo h($choiceExplanationItem['key']); ?>.</span>
-                                            <div class="choice-explanation-body">
-                                                <?php if ($choiceExplanationItem['text'] !== ''): ?>
-                                                    <p class="choice-statement"><?php echo h($choiceExplanationItem['text']); ?></p>
-                                                <?php endif; ?>
-                                                <?php if ($choiceExplanation['text'] !== ''): ?>
-                                                    <p><?php echo nl2brSafe($choiceExplanation['text']); ?></p>
-                                                <?php endif; ?>
-                                                <?php if ($choiceExplanation['reference'] !== ''): ?>
-                                                    <?php $choiceReferenceLabel = $choiceExplanation['reference_label'] !== '' ? $choiceExplanation['reference_label'] : '公式資料'; ?>
-                                                    <p class="explanation-reference">
-                                                        <a href="<?php echo h($choiceExplanation['reference']); ?>" target="_blank" rel="noopener noreferrer"><?php echo h($choiceReferenceLabel); ?></a>
-                                                    </p>
-                                                <?php endif; ?>
-                                            </div>
-                                        </li>
-                                    <?php endforeach; ?>
-                                </ul>
+                                <details class="choice-explanations-toggle">
+                                    <summary>選択肢ごとの解説</summary>
+                                    <ul class="choice-explanations">
+                                        <?php foreach ($choiceExplanationItems as $choiceExplanationItem): ?>
+                                            <?php $choiceExplanation = $choiceExplanationItem['explanation']; ?>
+                                            <li class="choice-explanation-item">
+                                                <span class="option-key"><?php echo h($choiceExplanationItem['key']); ?>.</span>
+                                                <div class="choice-explanation-body">
+                                                    <?php if ($choiceExplanationItem['text'] !== ''): ?>
+                                                        <p class="choice-statement"><?php echo h($choiceExplanationItem['text']); ?></p>
+                                                    <?php endif; ?>
+                                                    <?php if ($choiceExplanation['text'] !== ''): ?>
+                                                        <p><?php echo nl2brSafe($choiceExplanation['text']); ?></p>
+                                                    <?php endif; ?>
+                                                    <?php if ($choiceExplanation['reference'] !== ''): ?>
+                                                        <?php $choiceReferenceLabel = $choiceExplanation['reference_label'] !== '' ? $choiceExplanation['reference_label'] : '公式資料'; ?>
+                                                        <p class="explanation-reference">
+                                                            <a href="<?php echo h($choiceExplanation['reference']); ?>" target="_blank" rel="noopener noreferrer"><?php echo h($choiceReferenceLabel); ?></a>
+                                                        </p>
+                                                    <?php endif; ?>
+                                                </div>
+                                            </li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </details>
                             </div>
                         <?php endif; ?>
                     </div>


### PR DESCRIPTION
## Summary
- wrap the per-choice explanations in the results view inside a collapsible details element
- add styling for the new collapsible summary control to match the existing layout

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb27ad5fdc8327a126beaf697d75b7