### PR TITLE
Improve responsive layout of exam history view

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1447,10 +1447,13 @@ button.danger-action:disabled:hover {
   .history-summary {
     flex-direction: column;
     gap: 10px;
+    align-items: stretch;
+    justify-content: flex-start;
   }
 
   .history-summary-score {
     text-align: left;
+    align-self: flex-start;
   }
 
   .history-pagination {
@@ -1534,5 +1537,12 @@ button.danger-action:disabled:hover {
 
   .history-filters {
     flex-direction: column;
+    align-items: stretch;
+  }
+
+  .history-filter-group {
+    width: 100%;
+    min-width: 0;
+    flex: none;
   }
 }


### PR DESCRIPTION
## Summary
- adjust the exam history summary block to stack cleanly on narrow screens
- prevent mobile filter groups from stretching vertically so controls stay compact

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cb4b65d9c88327b677bd95765cd823