### PR TITLE
Remove redundant menu link

### DIFF
--- a/index.php
+++ b/index.php
@@ -930,7 +930,6 @@ if ($currentResultForStorage !== null) {
                 <button type="button" class="sidebar-close" id="sidebarClose" aria-label="カテゴリメニューを閉じる">&times;</button>
             </div>
             <nav class="sidebar-nav" aria-label="ページ切り替え">
-                <a href="./" class="sidebar-nav-link<?php echo $isHistoryView ? '' : ' active'; ?>">試験カテゴリ</a>
                 <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
             </nav>
             <h3 class="sidebar-section-title">試験カテゴリ</h3>


### PR DESCRIPTION
## Summary
- remove the redundant "試験カテゴリ" link from the sidebar menu

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb520ebe108327805dffb2a4e09007