### PR TITLE
Move exam history link to bottom of menu

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -83,7 +83,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-bottom: 16px;
+  margin: 24px 0 0;
 }
 
 .sidebar-nav-link {

--- a/index.php
+++ b/index.php
@@ -929,9 +929,6 @@ if ($currentResultForStorage !== null) {
                 <h2>メニュー</h2>
                 <button type="button" class="sidebar-close" id="sidebarClose" aria-label="カテゴリメニューを閉じる">&times;</button>
             </div>
-            <nav class="sidebar-nav" aria-label="ページ切り替え">
-                <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
-            </nav>
             <h3 class="sidebar-section-title">試験カテゴリ</h3>
             <?php if (!empty($categories)): ?>
                 <div class="category-accordion">
@@ -970,6 +967,9 @@ if ($currentResultForStorage !== null) {
             <?php else: ?>
                 <p class="empty-message">カテゴリが登録されていません。</p>
             <?php endif; ?>
+            <nav class="sidebar-nav" aria-label="ページ切り替え">
+                <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
+            </nav>
         </aside>
         <main class="main-content">
             <?php foreach ($errorMessages as $message): ?>


### PR DESCRIPTION
## Summary
- move the Exam History navigation link to the bottom of the sidebar menu
- adjust sidebar navigation spacing to match its new position

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb550094d0832796a238acb0a1b3c6