### PR TITLE
Move exam history link to bottom of menu

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -58,6 +58,8 @@ body {
   top: 24px;
   max-height: calc(100vh - 48px);
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .category-sidebar:focus {
@@ -73,6 +75,12 @@ body {
   margin-bottom: 16px;
 }
 
+.sidebar-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+}
+
 .sidebar-header h2 {
   margin: 0;
   font-size: 1.1rem;
@@ -83,7 +91,9 @@ body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
 }
 
 .sidebar-nav-link {

--- a/index.php
+++ b/index.php
@@ -929,47 +929,49 @@ if ($currentResultForStorage !== null) {
                 <h2>メニュー</h2>
                 <button type="button" class="sidebar-close" id="sidebarClose" aria-label="カテゴリメニューを閉じる">&times;</button>
             </div>
+            <div class="sidebar-content">
+                <h3 class="sidebar-section-title">試験カテゴリ</h3>
+                <?php if (!empty($categories)): ?>
+                    <div class="category-accordion">
+                        <?php foreach ($categories as $categoryId => $category): ?>
+                            <?php $examIds = examIdsForCategory($categories, $exams, $categoryId); ?>
+                            <?php $categoryExamCount = count($examIds); ?>
+                            <?php $isActiveCategory = $categoryId === $selectedCategoryId; ?>
+                            <details class="category-item"<?php echo $isActiveCategory ? ' open' : ''; ?>>
+                                <summary class="category-summary">
+                                    <span class="category-name"><?php echo h($category['name']); ?></span>
+                                    <span class="category-count" aria-hidden="true"><?php echo $categoryExamCount; ?></span>
+                                    <span class="accordion-icon" aria-hidden="true"></span>
+                                </summary>
+                                <?php if ($categoryExamCount > 0): ?>
+                                    <div class="exam-list">
+                                        <?php foreach ($examIds as $examId): ?>
+                                            <?php if (!isset($exams[$examId])) { continue; } ?>
+                                            <?php $exam = $exams[$examId]; ?>
+                                            <?php $isActiveExam = $examId === $selectedExamId; ?>
+                                            <form method="post" class="exam-select-form">
+                                                <input type="hidden" name="action" value="select_exam">
+                                                <input type="hidden" name="difficulty" value="<?php echo h($selectedDifficulty); ?>">
+                                                <input type="hidden" name="category_id" value="<?php echo h($categoryId); ?>">
+                                                <button type="submit" name="exam_id" value="<?php echo h($examId); ?>" class="exam-button<?php echo $isActiveExam ? ' active' : ''; ?>">
+                                                    <span class="exam-title"><?php echo h($exam['meta']['title']); ?></span>
+                                                </button>
+                                            </form>
+                                        <?php endforeach; ?>
+                                    </div>
+                                <?php else: ?>
+                                    <p class="empty-message accordion-empty">このカテゴリには試験が登録されていません。</p>
+                                <?php endif; ?>
+                            </details>
+                        <?php endforeach; ?>
+                    </div>
+                <?php else: ?>
+                    <p class="empty-message">カテゴリが登録されていません。</p>
+                <?php endif; ?>
+            </div>
             <nav class="sidebar-nav" aria-label="ページ切り替え">
                 <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
             </nav>
-            <h3 class="sidebar-section-title">試験カテゴリ</h3>
-            <?php if (!empty($categories)): ?>
-                <div class="category-accordion">
-                    <?php foreach ($categories as $categoryId => $category): ?>
-                        <?php $examIds = examIdsForCategory($categories, $exams, $categoryId); ?>
-                        <?php $categoryExamCount = count($examIds); ?>
-                        <?php $isActiveCategory = $categoryId === $selectedCategoryId; ?>
-                        <details class="category-item"<?php echo $isActiveCategory ? ' open' : ''; ?>>
-                            <summary class="category-summary">
-                                <span class="category-name"><?php echo h($category['name']); ?></span>
-                                <span class="category-count" aria-hidden="true"><?php echo $categoryExamCount; ?></span>
-                                <span class="accordion-icon" aria-hidden="true"></span>
-                            </summary>
-                            <?php if ($categoryExamCount > 0): ?>
-                                <div class="exam-list">
-                                    <?php foreach ($examIds as $examId): ?>
-                                        <?php if (!isset($exams[$examId])) { continue; } ?>
-                                        <?php $exam = $exams[$examId]; ?>
-                                        <?php $isActiveExam = $examId === $selectedExamId; ?>
-                                        <form method="post" class="exam-select-form">
-                                            <input type="hidden" name="action" value="select_exam">
-                                            <input type="hidden" name="difficulty" value="<?php echo h($selectedDifficulty); ?>">
-                                            <input type="hidden" name="category_id" value="<?php echo h($categoryId); ?>">
-                                            <button type="submit" name="exam_id" value="<?php echo h($examId); ?>" class="exam-button<?php echo $isActiveExam ? ' active' : ''; ?>">
-                                                <span class="exam-title"><?php echo h($exam['meta']['title']); ?></span>
-                                            </button>
-                                        </form>
-                                    <?php endforeach; ?>
-                                </div>
-                            <?php else: ?>
-                                <p class="empty-message accordion-empty">このカテゴリには試験が登録されていません。</p>
-                            <?php endif; ?>
-                        </details>
-                    <?php endforeach; ?>
-                </div>
-            <?php else: ?>
-                <p class="empty-message">カテゴリが登録されていません。</p>
-            <?php endif; ?>
         </aside>
         <main class="main-content">
             <?php foreach ($errorMessages as $message): ?>


### PR DESCRIPTION
## Summary
- move the Exam History navigation link to the bottom of the sidebar menu
- wrap the category list in a sidebar content section and add spacing so the Exam History link displays cleanly at the bottom

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb550094d0832796a238acb0a1b3c6