### PR TITLE
Add dedicated landing page for exam selection

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -37,6 +37,157 @@ body {
   min-width: 0;
 }
 
+.landing-hero {
+  background: linear-gradient(135deg, #dbeafe 0%, #eef2ff 100%);
+  border-radius: 18px;
+  padding: 32px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 20px 45px -28px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-hero h2 {
+  margin: 0;
+  font-size: 2rem;
+  color: var(--primary-dark);
+}
+
+.landing-lead {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1e293b;
+  max-width: 720px;
+}
+
+.landing-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.landing-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.landing-button.primary {
+  background: var(--primary);
+  color: #fff;
+  border: 1px solid transparent;
+  box-shadow: 0 12px 30px -18px rgba(29, 78, 216, 0.7);
+}
+
+.landing-button.primary:hover,
+.landing-button.primary:focus-visible {
+  background: var(--primary-dark);
+  color: #fff;
+  outline: none;
+  box-shadow: 0 18px 36px -20px rgba(30, 64, 175, 0.6);
+}
+
+.landing-button.secondary {
+  border: 1px solid var(--primary);
+  color: var(--primary);
+  background: rgba(255, 255, 255, 0.8);
+}
+
+.landing-button.secondary:hover,
+.landing-button.secondary:focus-visible {
+  background: var(--primary);
+  color: #fff;
+  outline: none;
+  box-shadow: 0 14px 32px -20px rgba(29, 78, 216, 0.5);
+}
+
+.landing-button.disabled {
+  border: 1px dashed var(--border);
+  background: rgba(226, 232, 240, 0.85);
+  color: #64748b;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.landing-highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin: 32px 0;
+}
+
+.landing-card {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 20px;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.landing-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--primary-dark);
+}
+
+.landing-metric {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.landing-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.landing-steps {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.4);
+}
+
+.landing-steps h3 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+  color: var(--primary-dark);
+}
+
+.landing-step-list {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.landing-step-list li {
+  line-height: 1.6;
+}
+
+.landing-step-list strong {
+  color: var(--primary-dark);
+}
+
 .sidebar-backdrop {
   display: none;
   position: fixed;
@@ -1441,6 +1592,14 @@ button.danger-action:disabled:hover {
     padding: 20px 16px 40px;
   }
 
+  .landing-hero {
+    padding: 28px;
+  }
+
+  .landing-highlights {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
   .layout {
     flex-direction: column;
     gap: 16px;
@@ -1542,6 +1701,27 @@ button.danger-action:disabled:hover {
 
   header h1 {
     font-size: 1.5rem;
+  }
+
+  .landing-hero {
+    padding: 24px;
+  }
+
+  .landing-hero h2 {
+    font-size: 1.6rem;
+  }
+
+  .landing-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .landing-button {
+    width: 100%;
+  }
+
+  .landing-highlights {
+    margin: 24px 0;
   }
 
   button:not(.sidebar-toggle):not(.sidebar-close) {


### PR DESCRIPTION
## Summary
- add a session-aware landing view so visitors see an independent top page before choosing exams
- introduce hero, highlight metrics, learning steps, and navigation updates for the landing experience
- style the landing layout and adjust responsive behavior for the new sections

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb7f38e7248327adbc845551ebdf22