### PR TITLE
Remove exam selection button from landing page

### DIFF
--- a/index.php
+++ b/index.php
@@ -1010,9 +1010,7 @@ if ($currentResultForStorage !== null) {
                         <p class="landing-lead">まだ問題データが登録されていません。data ディレクトリにJSONファイルを追加すると、ここから試験を選んで学習を始められます。</p>
                     <?php endif; ?>
                     <div class="landing-actions">
-                        <?php if ($totalExams > 0): ?>
-                            <a class="landing-button primary" href="?view=home">試験を選ぶ</a>
-                        <?php else: ?>
+                        <?php if ($totalExams === 0): ?>
                             <span class="landing-button disabled" role="text" aria-disabled="true">試験データを追加してください</span>
                         <?php endif; ?>
                         <a class="landing-button secondary" href="?view=history">受験履歴を見る</a>


### PR DESCRIPTION
## Summary
- remove the "試験を選ぶ" call-to-action button from the landing page so it no longer appears on the top screen
- keep the history link available and show the data upload notice only when no exams exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb840c0fd08327b32421b81ee2a6e8