### PR TITLE
Fix quiz submission when landing view query is present

### DIFF
--- a/index.php
+++ b/index.php
@@ -717,8 +717,10 @@ if ($selectedCategoryId !== '' && !isset($categories[$selectedCategoryId])) {
 }
 
 $requestedView = isset($_GET['view']) ? (string)$_GET['view'] : '';
+$requestMethod = isset($_SERVER['REQUEST_METHOD']) ? strtoupper((string)$_SERVER['REQUEST_METHOD']) : 'GET';
+$isPostRequest = $requestMethod === 'POST';
 
-if ($requestedView === 'landing') {
+if ($requestedView === 'landing' && !$isPostRequest) {
     if ($currentQuiz) {
         unset($_SESSION['current_quiz']);
         $currentQuiz = null;
@@ -738,7 +740,7 @@ if ($requestedView === 'landing') {
 $questionCountInput = '';
 $selectedDifficulty = sanitizeDifficultySelection($_SESSION['last_selected_difficulty'] ?? null);
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if ($isPostRequest) {
     $action = isset($_POST['action']) ? (string)$_POST['action'] : '';
 
     if (isset($_POST['difficulty'])) {


### PR DESCRIPTION
## Summary
- ensure the quiz session is not cleared when `view=landing` is present on POST requests by checking the request method first
- reuse the computed request-method flag when processing POST actions so submissions keep the active quiz

## Testing
- php -l index.php
- curl http://127.0.0.1:8000/index.php?view=landing (plus follow-up POSTs to select exam, start quiz, and submit answers) while the PHP built-in server was running

------
https://chatgpt.com/codex/tasks/task_e_68cbae1fbb208327a07c9c66ac02ea8b