### PR TITLE
Ensure history list clears after deleting records

### DIFF
--- a/index.php
+++ b/index.php
@@ -2339,6 +2339,9 @@ if ($currentResultForStorage !== null) {
                     historyState.results = [];
                     historyState.filtered = [];
                     historyState.page = 1;
+                    if (listElement) {
+                        listElement.innerHTML = '';
+                    }
                     if (paginationElement) {
                         paginationElement.hidden = true;
                     }


### PR DESCRIPTION
## Summary
- clear the rendered history list when all saved results are deleted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbbeb825408327840cb3e9ee60e068