### PR TITLE
Clear selections on landing view

### DIFF
--- a/index.php
+++ b/index.php
@@ -737,6 +737,12 @@ if ($requestedView === 'landing' && !$isPostRequest) {
     }
 }
 
+if (!$isPostRequest && $view === 'landing') {
+    $selectedCategoryId = '';
+    $selectedExamId = '';
+    unset($_SESSION['last_selected_category_id'], $_SESSION['last_selected_exam_id']);
+}
+
 $questionCountInput = '';
 $selectedDifficulty = sanitizeDifficultySelection($_SESSION['last_selected_difficulty'] ?? null);
 


### PR DESCRIPTION
## Summary
- reset the stored category and exam selections when the landing view is shown via GET
- ensure the sidebar starts collapsed and no exam is highlighted on the top page

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbc0ae711883279a3388f754c07720