### PR TITLE
Remove exam selection item from sidebar navigation

### DIFF
--- a/index.php
+++ b/index.php
@@ -1173,7 +1173,6 @@ if ($currentResultForStorage !== null) {
             <?php endif; ?>
             <nav class="sidebar-nav" aria-label="ページ切り替え">
                 <a href="index.php?view=landing" class="sidebar-nav-link<?php echo $isLandingView ? ' active' : ''; ?>">トップ</a>
-                <a href="?view=home" class="sidebar-nav-link<?php echo $isExamView ? ' active' : ''; ?>">試験を選ぶ</a>
                 <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
             </nav>
         </aside>


### PR DESCRIPTION
## Summary
- remove the unused "試験を選ぶ" link from the sidebar navigation so the menu only lists landing and history views

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbc33eca9883279dc17806c2d86908