### PR TITLE
Center landing page header title

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -511,6 +511,19 @@ header p {
   gap: 12px;
 }
 
+.app[data-view="landing"] header {
+  align-items: center;
+}
+
+.app[data-view="landing"] .header-top {
+  justify-content: center;
+}
+
+.app[data-view="landing"] header h1 {
+  width: 100%;
+  text-align: center;
+}
+
 .sidebar-toggle {
   display: none;
   align-items: center;


### PR DESCRIPTION
## Summary
- center the top page "資格試験問題集" title by updating the landing view header layout

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbc8daca4c83279b901dc78f2c55b5