### PR TITLE
Move sidebar navigation above category list

### DIFF
--- a/index.php
+++ b/index.php
@@ -1132,6 +1132,10 @@ if ($currentResultForStorage !== null) {
                 <h2>メニュー</h2>
                 <button type="button" class="sidebar-close" id="sidebarClose" aria-label="カテゴリメニューを閉じる">&times;</button>
             </div>
+            <nav class="sidebar-nav" aria-label="ページ切り替え">
+                <a href="index.php?view=landing" class="sidebar-nav-link<?php echo $isLandingView ? ' active' : ''; ?>">トップ</a>
+                <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
+            </nav>
             <h3 class="sidebar-section-title">試験カテゴリ</h3>
             <?php if (!empty($categories)): ?>
                 <div class="category-accordion">
@@ -1171,10 +1175,6 @@ if ($currentResultForStorage !== null) {
             <?php else: ?>
                 <p class="empty-message">カテゴリが登録されていません。</p>
             <?php endif; ?>
-            <nav class="sidebar-nav" aria-label="ページ切り替え">
-                <a href="index.php?view=landing" class="sidebar-nav-link<?php echo $isLandingView ? ' active' : ''; ?>">トップ</a>
-                <a href="?view=history" class="sidebar-nav-link<?php echo $isHistoryView ? ' active' : ''; ?>">受験履歴</a>
-            </nav>
         </aside>
         <main class="main-content">
             <?php foreach ($errorMessages as $message): ?>


### PR DESCRIPTION
## Summary
- move the sidebar navigation links for the landing and history views above the category list so they appear before "試験カテゴリ"

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbdc1169cc8327a04f77d52e416cf3