### PR TITLE
Remove redundant selection hint and adjust sidebar spacing

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -266,7 +266,7 @@ body {
 }
 
 .sidebar-section-title {
-  margin: 0 0 8px;
+  margin: 32px 0 8px;
   font-size: 1rem;
   font-weight: 700;
   color: var(--primary-dark);

--- a/index.php
+++ b/index.php
@@ -1267,7 +1267,6 @@ if ($currentResultForStorage !== null) {
                                 <span class="selected-exam-placeholder">下のボタンから試験を選択してください。</span>
                             <?php endif; ?>
                         </div>
-                        <small class="field-hint">メニューまたは下のボタンから試験を選択してください。</small>
                     </div>
                     <div class="form-field">
                         <label for="difficulty">難易度</label>


### PR DESCRIPTION
## Summary
- remove the redundant hint below the selected exam summary
- increase the spacing between the sidebar navigation links and the category heading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbe063f85c8327b0268e03bbcdd8e7