### PR TITLE
Center the application title in the header

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -507,8 +507,14 @@ header p {
 .header-top {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 12px;
+  position: relative;
+}
+
+.header-top h1 {
+  width: 100%;
+  text-align: center;
 }
 
 .app[data-view="landing"] header {
@@ -522,6 +528,13 @@ header p {
 .app[data-view="landing"] header h1 {
   width: 100%;
   text-align: center;
+}
+
+.header-top .sidebar-toggle {
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .sidebar-toggle {
@@ -1683,7 +1696,7 @@ button.danger-action:disabled:hover {
   }
 
   .header-top {
-    justify-content: flex-start;
+    justify-content: center;
   }
 
   .header-top .sidebar-toggle {


### PR DESCRIPTION
## Summary
- center the main header title by updating the `.header-top` layout so the title spans the full width
- keep the sidebar toggle accessible by absolutely positioning it beside the centered title
- preserve the centered appearance on narrow screens by updating the responsive rule

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbe0ca5c288327b1b3e92a3449549a