### PR TITLE
Fix landing header toggle alignment

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -518,11 +518,12 @@ header p {
 }
 
 .app[data-view="landing"] header {
-  align-items: center;
+  align-items: stretch;
 }
 
 .app[data-view="landing"] .header-top {
   justify-content: center;
+  width: 100%;
 }
 
 .app[data-view="landing"] header h1 {
@@ -536,6 +537,10 @@ header p {
   left: 0;
   transform: none;
   z-index: 1100;
+}
+
+.js-enabled.sidebar-open .sidebar-toggle {
+  display: none;
 }
 
 .sidebar-toggle {


### PR DESCRIPTION
## Summary
- ensure the landing header stretches across the page so the hamburger button matches the history view alignment
- hide the hamburger toggle whenever the sidebar is open to avoid button overlap

## Testing
- Manual verification on landing and history views at mobile width

------
https://chatgpt.com/codex/tasks/task_e_68cbe8c4882c832792aef1f62782d07a