### PR TITLE
Update history filters and hamburger icon

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -567,13 +567,13 @@ header p {
 .sidebar-toggle .hamburger {
   display: inline-flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 5px;
 }
 
 .sidebar-toggle .hamburger span {
   display: block;
-  width: 20px;
-  height: 2px;
+  width: 24px;
+  height: 3px;
   background: currentColor;
   border-radius: 999px;
 }


### PR DESCRIPTION
## Summary
- enlarge the hamburger toggle icon for better visibility
- replace the history view difficulty filter with category and exam selectors and rename the sort label to "並び順"
- update history filtering logic to support the new selectors and keep exam options in sync with the chosen category

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbeb7d0848832788bb50d0749a69e4