### PR TITLE
Show question counts in sidebar

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -445,6 +445,24 @@ body {
   min-width: 0;
 }
 
+.exam-button .exam-question-count {
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #334155;
+  background: #e2e8f0;
+  border-radius: 999px;
+  padding: 2px 8px;
+  line-height: 1.2;
+}
+
+.exam-button:hover .exam-question-count,
+.exam-button:focus .exam-question-count,
+.exam-button.active .exam-question-count {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
 .accordion-empty {
   margin: 0;
   padding: 12px;


### PR DESCRIPTION
## Summary
- add helpers to derive per-exam and per-category question totals
- display question counts for categories and exams in the sidebar UI
- style the exam buttons to show the new count badge clearly

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cc11e95de08327a81885a01a9e45a9