### PR TITLE
Add keyword search to landing page

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -188,6 +188,161 @@ body {
   color: var(--primary-dark);
 }
 
+.landing-search {
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 24px;
+  box-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 32px 0;
+}
+
+.landing-search h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--primary-dark);
+}
+
+.landing-search-text {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.landing-search-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+}
+
+.landing-search-label {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.landing-search-controls {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.landing-search-controls input[type="search"] {
+  flex: 1 1 260px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 1rem;
+}
+
+.landing-search-controls input[type="search"]:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(29, 78, 216, 0.15);
+}
+
+.landing-search-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.landing-search-summary-text {
+  margin: 0;
+}
+
+.landing-search-summary strong {
+  color: var(--primary);
+}
+
+.landing-search-summary .link-button {
+  padding: 8px 12px;
+  font-size: 0.85rem;
+}
+
+.search-result-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.search-result-card {
+  background: #f8fafc;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+}
+
+.search-result-card h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--primary-dark);
+}
+
+.search-result-meta {
+  margin: 4px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.search-result-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: #e2e8f0;
+  color: #334155;
+  line-height: 1.4;
+}
+
+.search-result-category {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.search-result-version {
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.search-result-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.search-result-form {
+  margin: auto 0 0;
+}
+
+.search-result-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
 .sidebar-backdrop {
   display: none;
   position: fixed;
@@ -1848,6 +2003,30 @@ button.danger-action:disabled:hover {
 
   .landing-highlights {
     margin: 24px 0;
+  }
+
+  .landing-search {
+    padding: 20px;
+    margin: 24px 0;
+  }
+
+  .landing-search-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .landing-search-summary {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .landing-search-summary .link-button {
+    width: 100%;
+  }
+
+  .search-result-list {
+    grid-template-columns: 1fr;
   }
 
   button:not(.sidebar-toggle):not(.sidebar-close) {


### PR DESCRIPTION
## Summary
- add helpers to normalize keywords and search exams by free-text on the landing view
- expose a landing page search form with results and quick selection actions
- style the new search section and results list with responsive layouts

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cc139b77888327ae7fa08cdff533b9