### PR TITLE
Fix mobile landing search input layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2011,10 +2011,13 @@ button.danger-action:disabled:hover {
   }
 
   .landing-search-controls {
-    flex-direction: row;
-    flex-wrap: nowrap;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
     gap: 8px;
+  }
+
+  .landing-search-controls input[type="search"] {
+    width: 100%;
   }
 
   .landing-search-summary {
@@ -2035,9 +2038,8 @@ button.danger-action:disabled:hover {
   }
 
   .landing-search-controls button {
-    width: auto;
-    flex: 0 0 auto;
-    white-space: nowrap;
+    width: 100%;
+    flex: none;
   }
 
   .open-sidebar-button {


### PR DESCRIPTION
## Summary
- adjust the landing page search control layout on narrow screens to stack vertically
- ensure the keyword input spans the full width on mobile for improved usability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc19b157648327861297ae4bb0e79b