### PR TITLE
Allow viewing detailed results from history

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1539,6 +1539,7 @@ button.danger-action:disabled:hover {
   flex-direction: column;
   gap: 6px;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .history-summary-title {
@@ -1574,6 +1575,19 @@ button.danger-action:disabled:hover {
   color: #334155;
   font-weight: 600;
   text-align: right;
+}
+
+.history-summary-aside {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.history-view-button {
+  font-size: 0.85rem;
+  padding: 6px 12px;
 }
 
 .history-entry[open] .history-summary-title {
@@ -1917,6 +1931,11 @@ button.danger-action:disabled:hover {
   .history-summary-score {
     text-align: left;
     align-self: flex-start;
+  }
+
+  .history-summary-aside {
+    align-items: stretch;
+    width: 100%;
   }
 
   .history-pagination {


### PR DESCRIPTION
## Summary
- normalize stored result payloads and add a `view_history_result` server action so history entries can be shown in the existing results view without resaving
- persist full result payloads with each attempt and wire up a hidden form plus client helpers to submit that payload when a history entry is opened
- tweak history list styling for the new “結果画面を開く” button and responsive layout adjustments

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cc1b29139c83278468ed12e09bc5be