### PR TITLE
Add exam counts to sidebar categories

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -510,6 +510,14 @@ body {
   font-weight: 600;
 }
 
+.category-counts {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
 .category-count {
   display: inline-flex;
   align-items: center;
@@ -520,7 +528,6 @@ body {
   font-size: 0.8rem;
   background: #e2e8f0;
   color: #1f2937;
-  margin-left: auto;
   flex-shrink: 0;
 }
 

--- a/index.php
+++ b/index.php
@@ -1705,14 +1705,18 @@ if ($currentResultForStorage !== null) {
                     <?php foreach ($categories as $categoryId => $category): ?>
                         <?php $examIds = examIdsForCategory($categories, $exams, $categoryId); ?>
                         <?php $categoryExamCount = count($examIds); ?>
+                        <?php $categoryExamCountLabel = number_format($categoryExamCount); ?>
                         <?php $categoryQuestionCount = questionCountForCategory($categories, $exams, $categoryId); ?>
                         <?php $categoryQuestionCountLabel = number_format($categoryQuestionCount); ?>
                         <?php $isActiveCategory = $categoryId === $selectedCategoryId; ?>
                         <details class="category-item"<?php echo $isActiveCategory ? ' open' : ''; ?>>
                             <summary class="category-summary">
                                 <span class="category-name"><?php echo h($category['name']); ?></span>
-                                <span class="category-count" aria-hidden="true"><?php echo $categoryQuestionCountLabel; ?>問</span>
-                                <span class="sr-only">カテゴリ内の総問題数: <?php echo $categoryQuestionCountLabel; ?>問</span>
+                                <span class="category-counts" aria-hidden="true">
+                                    <span class="category-count"><?php echo $categoryExamCountLabel; ?>試験</span>
+                                    <span class="category-count"><?php echo $categoryQuestionCountLabel; ?>問</span>
+                                </span>
+                                <span class="sr-only">カテゴリ内の試験数: <?php echo $categoryExamCountLabel; ?>件、総問題数: <?php echo $categoryQuestionCountLabel; ?>問</span>
                                 <span class="accordion-icon" aria-hidden="true"></span>
                             </summary>
                             <?php if ($categoryExamCount > 0): ?>


### PR DESCRIPTION
## Summary
- show the number of exams next to each category in the sidebar along with total questions
- add accessible text for screen readers and tweak the badge styles to support multiple counts

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cc7c1f8444832796bdb7e9dd5e6581