### PR TITLE
Adjust sidebar category counts layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -512,8 +512,9 @@ body {
 
 .category-counts {
   display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
   margin-left: auto;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- stack the exam and question count badges vertically within the sidebar category entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccf90cd0108327a3525ef519c16829