### PR TITLE
Enhance manual page layout

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1915,6 +1915,33 @@ button.danger-action:disabled:hover {
   font-size: 0.95rem;
 }
 
+.manual-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 4px 0 4px;
+}
+
+.manual-hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary-dark);
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  box-shadow: 0 14px 32px -26px rgba(29, 78, 216, 0.55);
+}
+
+.manual-hero-badge.is-accent {
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  box-shadow: 0 18px 40px -30px rgba(37, 99, 235, 0.65);
+}
+
 .manual-section {
   background: #fff;
   border: 1px solid var(--border);
@@ -1922,6 +1949,119 @@ button.danger-action:disabled:hover {
   padding: 28px;
   margin: 32px 0;
   box-shadow: 0 20px 48px -32px rgba(15, 23, 42, 0.4);
+}
+
+.manual-toc {
+  margin: 32px 0;
+}
+
+.manual-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.manual-toc-link {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  text-decoration: none;
+  background: linear-gradient(135deg, rgba(226, 232, 240, 0.3) 0%, rgba(241, 245, 249, 0.7) 100%);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 14px;
+  padding: 18px 20px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  color: #1f2937;
+  box-shadow: 0 22px 48px -34px rgba(15, 23, 42, 0.45);
+}
+
+.manual-toc-link:hover,
+.manual-toc-link:focus-visible {
+  transform: translateY(-2px);
+  border-color: var(--primary);
+  box-shadow: 0 28px 56px -32px rgba(29, 78, 216, 0.45);
+}
+
+.manual-toc-link:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.55);
+  outline-offset: 3px;
+}
+
+.manual-toc-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.manual-toc-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.22) 0%, rgba(29, 78, 216, 0.32) 100%);
+  color: var(--primary-dark);
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.manual-toc-icon {
+  font-size: 1.3rem;
+}
+
+.manual-toc-title {
+  font-weight: 700;
+  color: var(--primary-dark);
+  font-size: 1rem;
+}
+
+.manual-toc-description {
+  color: #475569;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.manual-section-header {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.manual-section-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, #1e40af 0%, #1d4ed8 100%);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.05rem;
+  box-shadow: 0 26px 58px -34px rgba(29, 78, 216, 0.55);
+}
+
+.manual-section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.manual-section-header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--primary-dark);
+}
+
+.manual-section-lead {
+  margin: 0;
+  color: #475569;
+  font-size: 0.95rem;
 }
 
 .manual-section h3 {
@@ -2146,9 +2286,27 @@ button.danger-action:disabled:hover {
     padding: 28px;
   }
 
+  .manual-toc {
+    margin: 24px 0;
+  }
+
+  .manual-toc-link {
+    padding: 16px 18px;
+  }
+
   .manual-section {
     padding: 24px;
     margin: 28px 0;
+  }
+
+  .manual-section-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .manual-section-number {
+    width: 48px;
+    height: 48px;
   }
 
   .manual-grid {
@@ -2293,6 +2451,18 @@ button.danger-action:disabled:hover {
     font-size: 1.6rem;
   }
 
+  .manual-toc-list {
+    grid-template-columns: 1fr;
+  }
+
+  .manual-toc-head {
+    align-items: flex-start;
+  }
+
+  .manual-toc-link {
+    padding: 14px 16px;
+  }
+
   .manual-hero-actions {
     flex-direction: column;
     align-items: stretch;
@@ -2319,6 +2489,11 @@ button.danger-action:disabled:hover {
   .manual-section {
     padding: 22px 18px;
     margin: 24px 0;
+  }
+
+  .manual-section-number {
+    width: 44px;
+    height: 44px;
   }
 
   .manual-step-list li {

--- a/index.php
+++ b/index.php
@@ -1893,9 +1893,64 @@ if ($currentResultForStorage !== null) {
                     </ol>
                 </section>
             <?php elseif ($view === 'manual'): ?>
+                <?php
+                $manualSections = [
+                    [
+                        'id' => 'manual-flow',
+                        'title' => '基本的な操作の流れ',
+                        'description' => '試験の選び方から採点までの4つのステップを順番に確認します。',
+                        'icon' => '🧭',
+                    ],
+                    [
+                        'id' => 'manual-layout',
+                        'title' => '画面構成と主な機能',
+                        'description' => 'アプリに登場する各画面の役割と便利な機能をまとめました。',
+                        'icon' => '🗂️',
+                    ],
+                    [
+                        'id' => 'manual-practice',
+                        'title' => '演習をスムーズに進めるポイント',
+                        'description' => '効率的に学習を進めるためのコツやヒントをご紹介します。',
+                        'icon' => '⚡',
+                    ],
+                    [
+                        'id' => 'manual-results',
+                        'title' => '採点結果と履歴の活用方法',
+                        'description' => '結果画面と履歴ページの見方、活用方法を詳しくご説明します。',
+                        'icon' => '📊',
+                    ],
+                    [
+                        'id' => 'manual-faq',
+                        'title' => 'よくある質問',
+                        'description' => '操作で困ったときに役立つ質問と回答をまとめています。',
+                        'icon' => '❓',
+                    ],
+                    [
+                        'id' => 'manual-next',
+                        'title' => '次のステップ',
+                        'description' => 'マニュアルを読み終えた後のアクションを確認しましょう。',
+                        'icon' => '🚀',
+                    ],
+                ];
+
+                $manualSectionIndexMap = [];
+                $manualSectionMetaMap = [];
+                foreach ($manualSections as $index => $manualSectionMeta) {
+                    $sectionNumber = $index + 1;
+                    $manualSectionMeta['number'] = $sectionNumber;
+                    $manualSectionMeta['number_label'] = sprintf('%02d', $sectionNumber);
+                    $manualSections[$index] = $manualSectionMeta;
+                    $manualSectionIndexMap[$manualSectionMeta['id']] = $sectionNumber;
+                    $manualSectionMetaMap[$manualSectionMeta['id']] = $manualSectionMeta;
+                }
+                ?>
                 <section class="manual-hero" aria-labelledby="manualTitle">
                     <h2 id="manualTitle">ご利用マニュアル</h2>
                     <p>このページでは、「資格試験問題集」アプリの使い方を、初めての方にも安心してご利用いただけるようにまとめています。カテゴリから試験を探し、演習を行い、結果を振り返るまでの流れを丁寧にご案内します。</p>
+                    <div class="manual-hero-meta">
+                        <span class="manual-hero-badge">✨ 初めての方向け</span>
+                        <span class="manual-hero-badge is-accent">💡 実践的なヒント付き</span>
+                    </div>
                     <ul class="manual-hero-list">
                         <li>目的の試験を素早く見つける方法</li>
                         <li>難易度や出題数の設定手順</li>
@@ -1909,8 +1964,44 @@ if ($currentResultForStorage !== null) {
                         <a class="landing-button secondary" href="#manual-faq">よくある質問を見る</a>
                     </div>
                 </section>
+                <nav class="manual-toc" aria-label="マニュアルの目次">
+                    <ol class="manual-toc-list">
+                        <?php foreach ($manualSections as $manualSection): ?>
+                            <li class="manual-toc-item">
+                                <a class="manual-toc-link" href="#<?php echo h($manualSection['id']); ?>">
+                                    <span class="manual-toc-head">
+                                        <span class="manual-toc-number"><?php echo h($manualSection['number_label']); ?></span>
+                                        <?php if (!empty($manualSection['icon'])): ?>
+                                            <span class="manual-toc-icon" aria-hidden="true"><?php echo $manualSection['icon']; ?></span>
+                                        <?php endif; ?>
+                                        <span class="manual-toc-title"><?php echo h($manualSection['title']); ?></span>
+                                    </span>
+                                    <?php if (!empty($manualSection['description'])): ?>
+                                        <span class="manual-toc-description"><?php echo h($manualSection['description']); ?></span>
+                                    <?php endif; ?>
+                                </a>
+                            </li>
+                        <?php endforeach; ?>
+                    </ol>
+                </nav>
                 <section class="manual-section" id="manual-flow">
-                    <h3>基本的な操作の流れ</h3>
+                    <?php
+                    $manualFlowMeta = $manualSectionMetaMap['manual-flow'] ?? ['title' => '基本的な操作の流れ', 'description' => '', 'number_label' => ''];
+                    $manualFlowTitle = $manualFlowMeta['title'] !== '' ? $manualFlowMeta['title'] : '基本的な操作の流れ';
+                    $manualFlowLead = $manualFlowMeta['description'] ?? '';
+                    $manualFlowNumberLabel = $manualFlowMeta['number_label'] ?? '';
+                    ?>
+                    <header class="manual-section-header">
+                        <?php if ($manualFlowNumberLabel !== ''): ?>
+                            <span class="manual-section-number"><?php echo h($manualFlowNumberLabel); ?></span>
+                        <?php endif; ?>
+                        <div class="manual-section-heading">
+                            <h3><?php echo h($manualFlowTitle); ?></h3>
+                            <?php if ($manualFlowLead !== ''): ?>
+                                <p class="manual-section-lead"><?php echo h($manualFlowLead); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </header>
                     <ol class="manual-step-list">
                         <li>
                             <span class="manual-step-number">1</span>
@@ -1963,7 +2054,23 @@ if ($currentResultForStorage !== null) {
                     </ol>
                 </section>
                 <section class="manual-section" id="manual-layout">
-                    <h3>画面構成と主な機能</h3>
+                    <?php
+                    $manualLayoutMeta = $manualSectionMetaMap['manual-layout'] ?? ['title' => '画面構成と主な機能', 'description' => '', 'number_label' => ''];
+                    $manualLayoutTitle = $manualLayoutMeta['title'] !== '' ? $manualLayoutMeta['title'] : '画面構成と主な機能';
+                    $manualLayoutLead = $manualLayoutMeta['description'] ?? '';
+                    $manualLayoutNumberLabel = $manualLayoutMeta['number_label'] ?? '';
+                    ?>
+                    <header class="manual-section-header">
+                        <?php if ($manualLayoutNumberLabel !== ''): ?>
+                            <span class="manual-section-number"><?php echo h($manualLayoutNumberLabel); ?></span>
+                        <?php endif; ?>
+                        <div class="manual-section-heading">
+                            <h3><?php echo h($manualLayoutTitle); ?></h3>
+                            <?php if ($manualLayoutLead !== ''): ?>
+                                <p class="manual-section-lead"><?php echo h($manualLayoutLead); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </header>
                     <div class="manual-grid">
                         <article class="manual-card">
                             <h4>カテゴリメニュー</h4>
@@ -2004,7 +2111,23 @@ if ($currentResultForStorage !== null) {
                     </div>
                 </section>
                 <section class="manual-section" id="manual-practice">
-                    <h3>演習をスムーズに進めるポイント</h3>
+                    <?php
+                    $manualPracticeMeta = $manualSectionMetaMap['manual-practice'] ?? ['title' => '演習をスムーズに進めるポイント', 'description' => '', 'number_label' => ''];
+                    $manualPracticeTitle = $manualPracticeMeta['title'] !== '' ? $manualPracticeMeta['title'] : '演習をスムーズに進めるポイント';
+                    $manualPracticeLead = $manualPracticeMeta['description'] ?? '';
+                    $manualPracticeNumberLabel = $manualPracticeMeta['number_label'] ?? '';
+                    ?>
+                    <header class="manual-section-header">
+                        <?php if ($manualPracticeNumberLabel !== ''): ?>
+                            <span class="manual-section-number"><?php echo h($manualPracticeNumberLabel); ?></span>
+                        <?php endif; ?>
+                        <div class="manual-section-heading">
+                            <h3><?php echo h($manualPracticeTitle); ?></h3>
+                            <?php if ($manualPracticeLead !== ''): ?>
+                                <p class="manual-section-lead"><?php echo h($manualPracticeLead); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </header>
                     <div class="manual-subsection">
                         <h4>カテゴリを切り替えて試験を探す</h4>
                         <p>学びたい分野が決まっている場合は、カテゴリ名から試験を絞り込むと目的の試験を素早く見つけられます。</p>
@@ -2037,7 +2160,23 @@ if ($currentResultForStorage !== null) {
                     </div>
                 </section>
                 <section class="manual-section" id="manual-results">
-                    <h3>採点結果と履歴の活用方法</h3>
+                    <?php
+                    $manualResultsMeta = $manualSectionMetaMap['manual-results'] ?? ['title' => '採点結果と履歴の活用方法', 'description' => '', 'number_label' => ''];
+                    $manualResultsTitle = $manualResultsMeta['title'] !== '' ? $manualResultsMeta['title'] : '採点結果と履歴の活用方法';
+                    $manualResultsLead = $manualResultsMeta['description'] ?? '';
+                    $manualResultsNumberLabel = $manualResultsMeta['number_label'] ?? '';
+                    ?>
+                    <header class="manual-section-header">
+                        <?php if ($manualResultsNumberLabel !== ''): ?>
+                            <span class="manual-section-number"><?php echo h($manualResultsNumberLabel); ?></span>
+                        <?php endif; ?>
+                        <div class="manual-section-heading">
+                            <h3><?php echo h($manualResultsTitle); ?></h3>
+                            <?php if ($manualResultsLead !== ''): ?>
+                                <p class="manual-section-lead"><?php echo h($manualResultsLead); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </header>
                     <div class="manual-grid">
                         <article class="manual-card">
                             <h4>採点結果画面で確認できること</h4>
@@ -2066,7 +2205,23 @@ if ($currentResultForStorage !== null) {
                     </div>
                 </section>
                 <section class="manual-section" id="manual-faq">
-                    <h3>よくある質問</h3>
+                    <?php
+                    $manualFaqMeta = $manualSectionMetaMap['manual-faq'] ?? ['title' => 'よくある質問', 'description' => '', 'number_label' => ''];
+                    $manualFaqTitle = $manualFaqMeta['title'] !== '' ? $manualFaqMeta['title'] : 'よくある質問';
+                    $manualFaqLead = $manualFaqMeta['description'] ?? '';
+                    $manualFaqNumberLabel = $manualFaqMeta['number_label'] ?? '';
+                    ?>
+                    <header class="manual-section-header">
+                        <?php if ($manualFaqNumberLabel !== ''): ?>
+                            <span class="manual-section-number"><?php echo h($manualFaqNumberLabel); ?></span>
+                        <?php endif; ?>
+                        <div class="manual-section-heading">
+                            <h3><?php echo h($manualFaqTitle); ?></h3>
+                            <?php if ($manualFaqLead !== ''): ?>
+                                <p class="manual-section-lead"><?php echo h($manualFaqLead); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </header>
                     <div class="manual-faq">
                         <details class="manual-faq-item">
                             <summary>出題数を変更できないときはどうすればよいですか？</summary>
@@ -2082,8 +2237,24 @@ if ($currentResultForStorage !== null) {
                         </details>
                     </div>
                 </section>
-                <section class="manual-section manual-next">
-                    <h3>次のステップ</h3>
+                <section class="manual-section manual-next" id="manual-next">
+                    <?php
+                    $manualNextMeta = $manualSectionMetaMap['manual-next'] ?? ['title' => '次のステップ', 'description' => '', 'number_label' => ''];
+                    $manualNextTitle = $manualNextMeta['title'] !== '' ? $manualNextMeta['title'] : '次のステップ';
+                    $manualNextLead = $manualNextMeta['description'] ?? '';
+                    $manualNextNumberLabel = $manualNextMeta['number_label'] ?? '';
+                    ?>
+                    <header class="manual-section-header">
+                        <?php if ($manualNextNumberLabel !== ''): ?>
+                            <span class="manual-section-number"><?php echo h($manualNextNumberLabel); ?></span>
+                        <?php endif; ?>
+                        <div class="manual-section-heading">
+                            <h3><?php echo h($manualNextTitle); ?></h3>
+                            <?php if ($manualNextLead !== ''): ?>
+                                <p class="manual-section-lead"><?php echo h($manualNextLead); ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </header>
                     <p>マニュアルを参考に、実際に演習を進めてみましょう。操作に迷ったときはいつでもこのページに戻って確認できます。</p>
                     <div class="manual-cta">
                         <a class="landing-button primary" href="?view=home">試験を選んで演習する</a>


### PR DESCRIPTION
## Summary
- derive manual chapter metadata so headings and numbering stay in sync without duplication
- add a richer manual landing experience with hero badges, table of contents, and numbered section headers
- extend manual styles for new components and responsive tweaks

## Testing
- php -l index.php
- php tests/run-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ce259ee68083279b2f191dfff17397