### PR TITLE
Adjust landing search layout on mobile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2532,13 +2532,13 @@ button.danger-action:disabled:hover {
   }
 
   .landing-search-controls {
-    flex-direction: column;
-    align-items: stretch;
     gap: 8px;
+    flex-wrap: nowrap;
   }
 
   .landing-search-controls input[type="search"] {
-    width: 100%;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .landing-search-summary {
@@ -2559,8 +2559,9 @@ button.danger-action:disabled:hover {
   }
 
   .landing-search-controls button {
-    width: 100%;
-    flex: none;
+    width: auto;
+    flex: 0 0 auto;
+    white-space: nowrap;
   }
 
   .open-sidebar-button {


### PR DESCRIPTION
## Summary
- keep the landing search form controls arranged horizontally on small screens by removing the column layout override
- allow the search input to flex and the button to size automatically on mobile so they remain side by side

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce815ca8ac8327b3300a937e9bad19