### PR TITLE
Fix mobile layout for landing search controls

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2558,7 +2558,7 @@ button.danger-action:disabled:hover {
     width: 100%;
   }
 
-  .landing-search-controls button {
+  .landing-search-controls button:not(.sidebar-toggle):not(.sidebar-close) {
     width: auto;
     flex: 0 0 auto;
     white-space: nowrap;


### PR DESCRIPTION
## Summary
- stop the mobile layout rule that forced the landing search button to take the full width
- ensure the button keeps its natural width so the keyword field can stay readable on narrow screens

## Testing
- Manual verification in a 390px wide viewport

------
https://chatgpt.com/codex/tasks/task_e_68ce87c4a4948327b9c6e32b9ab58b1b