### PR TITLE
Make navigation chrome sticky across the app

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -466,8 +466,8 @@ body {
   box-shadow: 0 35px 70px -50px rgba(15, 23, 42, 0.55);
   backdrop-filter: blur(18px);
   position: sticky;
-  top: 24px;
-  max-height: calc(100vh - 48px);
+  top: calc(env(safe-area-inset-top, 0px) + 24px);
+  max-height: calc(100vh - 48px - env(safe-area-inset-top, 0px));
   overflow-y: auto;
 }
 
@@ -782,6 +782,15 @@ header {
   flex-direction: column;
   gap: 12px;
   margin-bottom: 32px;
+  position: sticky;
+  top: calc(env(safe-area-inset-top, 0px) + 0px);
+  z-index: 950;
+  padding: 16px 20px;
+  background: var(--surface-strong);
+  border: 1px solid rgba(99, 102, 241, 0.16);
+  border-radius: 24px;
+  box-shadow: 0 32px 70px -48px rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(18px);
 }
 
 header h1 {
@@ -2633,6 +2642,11 @@ button.danger-action:disabled:hover {
 }
 
 @media (max-width: 640px) {
+  header {
+    padding: 14px 16px;
+    border-radius: 20px;
+  }
+
   .app {
     padding: 16px 12px 32px;
   }


### PR DESCRIPTION
## Summary
- keep the main header visible by making it sticky with a translucent surface treatment
- respect safe-area insets when positioning the sidebar and maintain its full height on scroll
- tweak the sticky header padding on small screens for better spacing

## Testing
- php -l index.php

------
https://chatgpt.com/codex/tasks/task_e_68cf3994f60483278426a83a3e5b97d3