### PR TITLE
Add bottom spacing to category sidebar

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -463,6 +463,7 @@ body {
   border: 1px solid rgba(99, 102, 241, 0.18);
   border-radius: 24px;
   padding: 24px;
+  padding-bottom: calc(24px + 32px + env(safe-area-inset-bottom, 0px));
   box-shadow: 0 35px 70px -50px rgba(15, 23, 42, 0.55);
   backdrop-filter: blur(18px);
   position: sticky;
@@ -2611,6 +2612,7 @@ button.danger-action:disabled:hover {
     border: none;
     box-shadow: 0 20px 50px rgba(15, 23, 42, 0.35);
     padding: 24px 20px;
+    padding-bottom: calc(24px + 32px + env(safe-area-inset-bottom, 0px));
     overflow-y: auto;
     z-index: 1000;
   }


### PR DESCRIPTION
## Summary
- add extra bottom padding to the desktop category sidebar so the final items remain visible and account for device safe areas
- apply matching padding to the mobile slide-in sidebar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf3d4f718083278a27a4b4755642c6